### PR TITLE
update syntex_syntax a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Automated tests of FFI bindings.
 """
 
 [dependencies]
-syntex_syntax = "0.20.0"
+syntex_syntax = "0.21.0"
 gcc = "0.3.14"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Automated tests of FFI bindings.
 """
 
 [dependencies]
-syntex_syntax = "0.19.1"
+syntex_syntax = "0.20.0"
 gcc = "0.3.14"
 
 [workspace]


### PR DESCRIPTION
syntex_syntax-0.20.0 depends on libc-0.2, whereas syntex_syntax-0.19.1
on libc-0.1.

it makes compilation more simple for new targets (openbsd on i386 in mind).