### PR TITLE
panic! on non-repr(C) structs only if the struct should not be skipped

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1394,7 +1394,7 @@ impl<'a, 'v> Visitor<'v> for Generator<'a> {
                         *a == ReprAttr::ReprExtern
                     })
                 });
-                if !is_c {
+                if !is_c && !(self.opts.skip_struct)(&i.ident.to_string()) {
                     panic!("{} is not marked #[repr(C)]", i.ident);
                 }
                 self.test_struct(&i.ident.to_string(), s);


### PR DESCRIPTION
Currently if some API struct is not `repr(C)` ctest will always panic independently of whether the users decided to "skip" the struct.

This commits ignores those structs that the user decided to skip when it comes to enforcing `repr(C)`.

I want to introduce ctest into a project that is currently very broken, and panicking here prevents me from fixing things incrementally. 