### PR TITLE
allow deprecated declarations on non-msvc targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,7 +582,8 @@ impl TestGenerator {
         } else {
             cfg.flag("-Wall").flag("-Wextra").flag("-Werror")
                .flag("-Wno-unused-parameter")
-               .flag("-Wno-type-limits");
+               .flag("-Wno-type-limits")
+               .flag("-Wno-deprecated-declarations"); // allow deprecated items
         }
 
         for flag in self.flags.iter() {


### PR DESCRIPTION
Because of -Werror, -Wextra, ... ctest will error on deprecated declarations. Skipping them is not a good solution because then they are not checked for anything.

This PR disables the `deprecated-declarations` warning to allow testing these.