### PR TITLE
Add support for arrays in extern statics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,37 @@
-language: rust
-rust:
-  - stable
-  - beta
-  - nightly
+dist: trusty
 sudo: false
+language: rust
+
+matrix:
+  fast_finish: true
+  include:
+    - name: "stable"
+      rust: stable
+    - name: "beta"
+      rust: beta
+    - name: "nightly"
+      rust: nightly
+      after_success:
+        - travis-cargo --only nightly doc-upload
+    - name: "libc-test"
+      rust: nightly
+      os: osx
+      osx_image: xcode9.4
+      after_script:
+        - git clone https://github.com/rust-lang/libc
+        - sed -i '' 's@ctest = "0.2.2"@ctest = { path = "../.." }@g' libc/libc-test/Cargo.toml
+        - cd libc
+        - cargo generate-lockfile --manifest-path libc-test/Cargo.toml
+        - |
+          export TARGET=x86_64-apple-darwin
+          sh ci/run.sh $TARGET
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo test
   - cargo test --manifest-path testcrate/Cargo.toml
   - cargo doc --no-deps
-after_success:
-  - travis-cargo --only nightly doc-upload
+
 notifications:
   email:
     on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctest"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ my-sys-library = { path = "../my-sys-library" }
 libc = "0.2"
 
 [build-dependencies]
-ctest = "0.1"
+ctest = "0.2"
 ```
 
 Next, add a build script to `systest/build.rs`:

--- a/testcrate/src/t1.c
+++ b/testcrate/src/t1.c
@@ -40,8 +40,12 @@ uint8_t (*T1_static_right2)(uint8_t, uint8_t) = foo;
 uint32_t (*(*T1_fn_ptr_s)(uint8_t))(uint16_t) = nested;
 uint32_t (*(*T1_fn_ptr_s2)(uint8_t(*arg0)(uint8_t), uint16_t(*arg1)(uint16_t)))(uint16_t) = nested2;
 
-int32_t T1_arr3[2] = {0};
-int32_t T1_arr4[2][3] = {0};
-int32_t T1_arr5[1][2][3] = {0};
+const int32_t T1_arr0[2] = {0, 0};
+const int32_t T1_arr1[2][3] = {{0, 0, 0}, {0, 0, 0}};
+const int32_t T1_arr2[1][2][3] = {{{0, 0, 0}, {0, 0, 0}}};
 
-int32_t T1_arr42[1][2][3] = {0};
+int32_t T1_arr3[2] = {0, 0};
+int32_t T1_arr4[2][3] = {{0, 0, 0}, {0, 0, 0}};
+int32_t T1_arr5[1][2][3] = {{{0, 0, 0}, {0, 0, 0}}};
+
+int32_t T1_arr42[1][2][3] = {{{0, 0, 0}, {0, 0, 0}}};

--- a/testcrate/src/t1.c
+++ b/testcrate/src/t1.c
@@ -39,3 +39,9 @@ uint8_t (*T1_static_right2)(uint8_t, uint8_t) = foo;
 
 uint32_t (*(*T1_fn_ptr_s)(uint8_t))(uint16_t) = nested;
 uint32_t (*(*T1_fn_ptr_s2)(uint8_t(*arg0)(uint8_t), uint16_t(*arg1)(uint16_t)))(uint16_t) = nested2;
+
+int32_t T1_arr3[2] = {0};
+int32_t T1_arr4[2][3] = {0};
+int32_t T1_arr5[1][2][3] = {0};
+
+int32_t T1_arr42[1][2][3] = {0};

--- a/testcrate/src/t1.h
+++ b/testcrate/src/t1.h
@@ -66,3 +66,13 @@ uint32_t (*(*T1_fn_ptr_s)(uint8_t))(uint16_t);
 // uint8_t -> uint8_t, and returning a function pointer to a function taking a
 // uint16_t and returning a uint32_t
 uint32_t (*(*T1_fn_ptr_s2)(uint8_t(*)(uint8_t), uint16_t(*)(uint16_t)))(uint16_t);
+
+const int32_t T1_arr0[2] = {0};
+const int32_t T1_arr1[2][3] = {0};
+const int32_t T1_arr2[1][2][3] = {0};
+
+int32_t T1_arr3[2];
+int32_t T1_arr4[2][3];
+int32_t T1_arr5[1][2][3];
+
+int32_t T1_arr42[1][2][3];

--- a/testcrate/src/t1.h
+++ b/testcrate/src/t1.h
@@ -47,14 +47,14 @@ void T1j(int32_t a[4]);
 #define T1C 4
 
 extern uint32_t T1static;
-const uint8_t T1_static_u8;
+extern const uint8_t T1_static_u8;
 uint8_t T1_static_mut_u8;
 uint8_t (*T1_static_mut_fn_ptr)(uint8_t, uint8_t);
-uint8_t (*const T1_static_const_fn_ptr_unsafe)(uint8_t, uint8_t);
-void (*const T1_static_const_fn_ptr_unsafe2)(uint8_t);
-void (*const T1_static_const_fn_ptr_unsafe3)(void);
+extern uint8_t (*const T1_static_const_fn_ptr_unsafe)(uint8_t, uint8_t);
+extern void (*const T1_static_const_fn_ptr_unsafe2)(uint8_t);
+extern void (*const T1_static_const_fn_ptr_unsafe3)(void);
 
-const uint8_t T1_static_right;
+extern const uint8_t T1_static_right;
 uint8_t (*T1_static_right2)(uint8_t, uint8_t);
 
 // T1_fn_ptr_nested: function pointer to a function, taking a uint8_t, and
@@ -67,12 +67,18 @@ uint32_t (*(*T1_fn_ptr_s)(uint8_t))(uint16_t);
 // uint16_t and returning a uint32_t
 uint32_t (*(*T1_fn_ptr_s2)(uint8_t(*)(uint8_t), uint16_t(*)(uint16_t)))(uint16_t);
 
-const int32_t T1_arr0[2] = {0};
-const int32_t T1_arr1[2][3] = {0};
-const int32_t T1_arr2[1][2][3] = {0};
+extern const int32_t T1_arr0[2];
+extern const int32_t T1_arr1[2][3];
+extern const int32_t T1_arr2[1][2][3];
 
-int32_t T1_arr3[2];
-int32_t T1_arr4[2][3];
-int32_t T1_arr5[1][2][3];
+extern int32_t T1_arr3[2];
+extern int32_t T1_arr4[2][3];
+extern int32_t T1_arr5[1][2][3];
 
-int32_t T1_arr42[1][2][3];
+extern int32_t T1_arr42[1][2][3];
+
+struct Q {
+  uint8_t* q0;
+  uint8_t** q1;
+  uint8_t q2;
+};

--- a/testcrate/src/t1.rs
+++ b/testcrate/src/t1.rs
@@ -101,3 +101,10 @@ extern "C" {
     #[link_name = "T1_arr42"]
     pub static mut T1_arr6: [[[i32; 3]; 2]; 1];
 }
+
+#[repr(C)]
+pub struct Q {
+    pub q0: *mut u8,
+    pub q1: *mut *mut u8,
+    pub q2: u8,
+}

--- a/testcrate/src/t1.rs
+++ b/testcrate/src/t1.rs
@@ -87,5 +87,17 @@ extern "C" {
 
     pub static T1_fn_ptr_s: unsafe extern "C" fn(u8) -> extern fn(u16)->u32;
     pub static T1_fn_ptr_s2: unsafe extern "C" fn(extern fn(u8)->u8,
-                                                  extern fn(u16)->u16) -> extern fn(u16)->u32;
+                                                  extern fn(u16)->u16)
+                                                  -> extern fn(u16)->u32;
+
+    pub static T1_arr0: [i32; 2];
+    pub static T1_arr1: [[i32; 3]; 2];
+    pub static T1_arr2: [[[i32; 3]; 2]; 1];
+
+    pub static mut T1_arr3: [i32; 2];
+    pub static mut T1_arr4: [[i32; 3]; 2];
+    pub static mut T1_arr5: [[[i32; 3]; 2]; 1];
+
+    #[link_name = "T1_arr42"]
+    pub static mut T1_arr6: [[[i32; 3]; 2]; 1];
 }


### PR DESCRIPTION
This PR also adds a CI build bot that builds libc-test using `ctest` to verify that changes to ctest do not break libc.